### PR TITLE
v0.0.2 Update

### DIFF
--- a/docs/ex/basic.rst
+++ b/docs/ex/basic.rst
@@ -97,6 +97,75 @@ by user-defined bounds on the segmented objects::
 This pipeline save both the binary segmentation and the labeled volume where
 each class is represented by a different color.
 
+Specifying Data Dependencies
+----------------------------
+
+When running FLoRIN classification, it can be helpful to have the original
+image data to be able to look at the grayscale properties of segmented objects.
+This requires looking back through the pipeline to find the original image
+data. FLoRIN allows back-references to prior operations in the pipeline using
+keyword arguments to operations
+
+    .. code-block:: python
+
+    import florin
+    import florin.conncomp as conncomp
+    import florin.morphology as morphology
+    import florin.thresholding as thresholding
+
+    # Create the load function before the pipeline to be able to use it in
+    # multiple non-sequential operations.
+    loader = florin.load()
+
+    # Set up a serial pipeline
+    pipeline = florin.Serial(
+        # Load in the volume from file with our predefined load operation
+        loader,
+
+        # Tile the volume into overlapping 64 x 64 x 10 subvolumes
+        florin.tile(shape=(10, 64, 64), stride=(10, 32, 32)),
+
+        # Threshold with NDNT
+        thresholding.ndnt(shape=(10, 64, 64), thresshold=0.3),
+
+        # Clean up a little bit
+        morphology.binary_opening(),
+
+        # Save the output to a TIFF stack
+        florin.save('segmented.tiff'),
+
+        # Find connected components
+        conncomp.label(),
+        morphology.remove_small_holes(min_size=20),
+
+        # regionprops() can use the original image data to provide extra
+        # information about the connected components. Pass the loader as
+        # `intensity_image=loader` to pass the output of loader forward to
+        # regionprops()
+        conncomp.regionprops(intensity_image=loader),
+
+        # Classify the connected components by their volume and dimensions
+        florin.classify(
+            florin.bounds_classifier(
+                'cell',
+                area=(100, 300),
+                depth=(10, 25),
+                width=(50, 100),
+                height=(50, 100)
+            ),
+            florin.bounds_classifier('vasculature')
+        ),
+
+        # Reconstruct the labeled volume
+        florin.reconstruct(),
+
+        # Write out the labeled volume
+        florin.save('labeled.tiff')
+    )
+
+    # Run the pipeline
+    segmented = pipeline()
+
 Closing Remarks
 ---------------
 

--- a/florin/__init__.py
+++ b/florin/__init__.py
@@ -38,6 +38,7 @@ tile
 from .classification import classify, FlorinClassifier
 from .closure import florinate
 from .io import load, save
+from .log_utils import FlorinLogger
 from .tiling import tile, join
 from .pipelines.pipeline import PipelineInput
 from .pipelines import BalsamPipeline as Balsam
@@ -51,3 +52,5 @@ from .reconstruction import reconstruct
 
 bounds_classifier = FlorinClassifier
 pipeline_input = PipelineInput()
+
+logger = FlorinLogger()

--- a/florin/__init__.py
+++ b/florin/__init__.py
@@ -39,6 +39,7 @@ from .classification import classify, FlorinClassifier
 from .closure import florinate
 from .io import load, save
 from .tiling import tile, join
+from .pipelines.pipeline import PipelineInput
 from .pipelines import BalsamPipeline as Balsam
 from .pipelines import MPIPipeline as MPI
 from .pipelines import MPITaskQueuePipeline as MPITaskQueue
@@ -49,3 +50,4 @@ from .pipelines import WorkQueuePipeline as WorkQueue
 from .reconstruction import reconstruct
 
 bounds_classifier = FlorinClassifier
+pipeline_input = PipelineInput()

--- a/florin/__init__.py
+++ b/florin/__init__.py
@@ -35,10 +35,12 @@ tile
     Split a single array into sub-arrays.
 """
 
-from .classification import classify, FlorinClassifier
+
+from .log_utils import logger
+
 from .closure import florinate
+from .classification import classify, FlorinClassifier
 from .io import load, save
-from .log_utils import FlorinLogger
 from .tiling import tile, join
 from .pipelines.pipeline import PipelineInput
 from .pipelines import BalsamPipeline as Balsam
@@ -52,5 +54,3 @@ from .reconstruction import reconstruct
 
 bounds_classifier = FlorinClassifier
 pipeline_input = PipelineInput()
-
-logger = FlorinLogger()

--- a/florin/__init__.py
+++ b/florin/__init__.py
@@ -41,6 +41,7 @@ from .io import load, save
 from .tiling import tile, join
 from .pipelines import BalsamPipeline as Balsam
 from .pipelines import MPIPipeline as MPI
+from .pipelines import MPITaskQueuePipeline as MPITaskQueue
 from .pipelines import MultiprocessingPipeline as Multiprocess
 from .pipelines import MultithreadingPipeline as Multithread
 from .pipelines import SerialPipeline as Serial

--- a/florin/closure.py
+++ b/florin/closure.py
@@ -8,9 +8,11 @@ florinate
 """
 
 from collections import Sequence
+from itertools import count
 import functools
 
-from florin.context import FlorinContext
+from florin.context import FlorinMetadata
+from florin.graph import FlorinNode
 
 
 def florinate(func):
@@ -57,16 +59,22 @@ def florinate(func):
     """
     @functools.wraps(func)
     def wrapper(*wrapper_args, **wrapper_kwargs):
-        """Function wrapper that saves args and keyword arguments."""
-        @functools.wraps(func)
-        def delayed(*args, **kwargs):
-            """Wrapper for deferred function calls with persistent arguments"""
-            kwargs.update(wrapper_kwargs)
-            if isinstance(args[0], Sequence) and isinstance(args[0][-1], FlorinContext):
-                innerargs = tuple(args[0][:-1]) + wrapper_args
-                return func(*innerargs, **kwargs), args[0][-1]
-            else:
-                innerargs = args + wrapper_args
-                return func(*innerargs, **kwargs)
-        return delayed
+        """Function wrapper that saves args and keyword arguments.
+
+        When args and keyword args are passed, the function is wrapped in a
+        FlorinNode instance and the arguments are saved for future use.
+
+        Parameters
+        ----------
+        *args
+        **kwargs
+            Arguments and keyword arguments to be passed to the wrapped
+            function when called at a later time.
+
+        Returns
+        -------
+        FlorinNode
+            The graph node representing the parameterized function.
+        """
+        return FlorinNode(func, *wrapper_args, **wrapper_kwargs)
     return wrapper

--- a/florin/context.py
+++ b/florin/context.py
@@ -2,27 +2,32 @@
 
 Classes
 -------
-FlorinContext
-    Context for data flowing through a pipeline.
+FlorinMetadata
+    Metadata for data flowing through a pipeline.
 """
 
 
-class FlorinContext(object):
-    """Context for data flowing through a pipeline."""
+class FlorinMetadata(dict):
+    """Metadata for data flowing through a pipeline.
 
-    def __init__(self, **kwargs):
-        for key, val in kwargs.items():
-            setattr(self, key, val)
+    Notes
+    -----
+    To incorporate Metadata into the pipeline, return it from an operation in a
+    pair with the output of the function, e.g. ``return output, metadata``.
+    """
 
-    def __getitem__(self, key):
-        return getattr(self, key)
-
-    def __setitem__(self, key, val):
-        setattr(self, key, val)
-
-    def __contains__(self, key):
+    def __getattr__(self, key):
         try:
-            getattr(self, key)
-            return True
-        except AttributeError:
-            return False
+            return self[key]
+        except KeyError:
+            return super(FlorinMetadata, self).__getattr__(key)
+
+    def __setattr__(self, key, val):
+        self[key] = val
+
+    def __delattr__(self, key):
+        del self[key]
+
+    def update(self, other):
+        super(FlorinMetadata, self).update(other)
+        return self

--- a/florin/exposure.py
+++ b/florin/exposure.py
@@ -1,0 +1,47 @@
+"""Helper functions for modifying the grayscale histogram of an image.
+
+Functions
+---------
+histogram
+    Return histogram of image.
+equalize_hist
+    Return image after histogram equalization.
+equalize_adapthist
+    Contrast Limited Adaptive Histogram Equalization (CLAHE).
+rescale_intensity
+    Return image after stretching or shrinking its intensity levels.
+cumulative_distribution
+    Return cumulative distribution function (cdf) for the given image.
+adjust_gamma
+    Performs Gamma Correction on the input image.
+adjust_sigma
+    Performs Sigmoid Correction on the input image.
+adjust_log
+    Determine if an image is low contrast.
+
+Notes
+-----
+The functions defined here are wrappers for functions in the `skimage.exposure`
+module. Full documentation may be found in the `scikit-image documentation`_.
+
+.. _scikit-image documentation: https://scikit-image.org/docs/stable/api/skimage.exposure.html
+
+"""
+
+import skimage.exposure
+
+from florin.closure import florinate
+
+
+histogram = florinate(skimage.exposure.histogram)
+equalize_hist = florinate(skimage.exposure.equalize_hist)
+equalize_adapthist = florinate(skimage.exposure.equalize_adapthist)
+rescale_intensity = florinate(skimage.exposure.rescale_intensity)
+cumulative_distribution = florinate(skimage.exposure.cumulative_distribution)
+adjust_gamma = florinate(skimage.exposure.adjust_gamma)
+adjust_log = florinate(skimage.exposure.adjust_log)
+
+
+__all__ = ['histogram', 'equalize_hist', 'equalize_adapthist',
+           'rescale_intensity', 'cumulative_distribution', 'adjust_gamma',
+           'adjust_log']

--- a/florin/graph/__init__.py
+++ b/florin/graph/__init__.py
@@ -1,2 +1,2 @@
-from .florin_graph import FlorinOrderedDiGraph
+from .florin_graph import FlorinOrderedMultiDiGraph
 from .florin_node import FlorinNode

--- a/florin/graph/__init__.py
+++ b/florin/graph/__init__.py
@@ -1,0 +1,2 @@
+from .florin_graph import FlorinOrderedDiGraph
+from .florin_node import FlorinNode

--- a/florin/graph/florin_graph.py
+++ b/florin/graph/florin_graph.py
@@ -1,0 +1,65 @@
+"""Dependency graphs for operation pipelines.
+
+Classes
+-------
+FlorinOrderedDiGraph
+    Ordered directed graph of a FLoRIN pipeline.
+"""
+
+import copy
+import uuid
+
+import networkx as nx
+
+from florin.context import FlorinMetadata
+from florin.graph.florin_node import FlorinNode
+
+
+class FlorinOrderedMultiDiGraph(nx.OrderedMultiDiGraph):
+
+    def __init__(self, incoming_graph_data=None, **attrs):
+        super(FlorinOrderedDiGraph, self).__init__(
+            incoming_graph_data=incoming_graph_data, **attrs)
+
+        self.last = None
+
+    def add(self, node, **kwargs):
+        self.add_node(node, **kwargs)
+        for dep in node.args:
+            if isinstance(dep, FlorinNode):
+                self.add_edge(dep, node, result=None)
+        for key, dep in node.kwargs.items():
+            if isinstance(dep, FlorinNode):
+                attrs = {key: None}
+                self.add_edge(dep, node, **attrs)
+        node.graph = self
+        self.last = node
+
+    def __call__(self, data):
+        # Pull any metadata and generate a unique key for the multigraph.
+        metadata = None
+        data_key = str(uuid.uuid4())
+
+        if isinstance(data, tuple) and isinstance(data[-1], FlorinMetadata):
+            metadata = data[-1]
+            data = data[:-1]
+
+        data_edges = []
+
+        # Run the data through the graph and collect the used multigraph edges
+        # to delete once processing is done.
+        for i, node in enumerate(self.nodes):
+            data_edges.append(node)
+            if i > 0:
+                result = node(data_key=data_key)
+            else:
+                result = node(data=data, data_key=data_key)
+
+        # Remove multigraph edges associated with this particular data flow to
+        # limit memory consumption.
+        self.remove_edges_from([(data_edges[i], data_edges[i + 1], data_key)
+                                for i in range(len(data_edges) - 1)])
+
+        if metadata is not None:
+            return result, metadata
+        return result

--- a/florin/graph/florin_graph.py
+++ b/florin/graph/florin_graph.py
@@ -18,7 +18,7 @@ from florin.graph.florin_node import FlorinNode
 class FlorinOrderedMultiDiGraph(nx.OrderedMultiDiGraph):
 
     def __init__(self, incoming_graph_data=None, **attrs):
-        super(FlorinOrderedDiGraph, self).__init__(
+        super(FlorinOrderedMultiDiGraph, self).__init__(
             incoming_graph_data=incoming_graph_data, **attrs)
 
         self.last = None

--- a/florin/graph/florin_node.py
+++ b/florin/graph/florin_node.py
@@ -1,0 +1,134 @@
+"""Graph nodes for operations in a FLoRIN pipeline.
+
+Classes
+-------
+FlorinNode
+    Graph node for partial function application with data dependencies.
+"""
+
+from itertools import count
+import weakref
+
+import networkx as nx
+
+
+class MetaFlorinNode(type):
+    """Metaclass for automatic id assignment to FlorinNodes."""
+
+    def __new__(cls, name, bases, dct):
+        x = super().__new__(cls, name, bases, dct)
+        x._counter = count(1)
+        return x
+
+class FlorinNode(object, metaclass=MetaFlorinNode):
+    """Graph node for partial function application with data dependencies.
+
+    Parameters
+    ----------
+    operation : callable
+        The function/operation that this node represents.
+
+    Other Parameters
+    ----------------
+    Any reusable arguments or keyword arguments to be applied over multiple
+    calls to this function.
+
+    Attributes
+    ----------
+    id : int
+        Unique integer id of this node.
+    operation : callable
+        The operation represented by this node.
+    dependencies : list of FlorinNode
+        Nodes that must be run before this node can be run. These are stored in
+        the same order they are passed to FlorinNode, and will be passed to
+        ``operation`` in the same order.
+    keyword_dependencies : dict of FlorinNode
+        Nodes that must be run before this node can be run referenced by a
+        given name.
+    """
+
+    def __init__(self, operation, *args, graph=None, **kwargs):
+        self.id = next(self._counter)
+        try:
+            self.__name__ = operation.__name__
+        except AttributeError:
+            self.__name__ = operation.__class__.__name__
+        self.operation = operation
+        self.graph = graph
+        self.args = args
+        self.kwargs = kwargs
+
+    def __call__(self, data=None, data_key=None):
+        """Add dependencies to this node.
+
+        Parameters
+        ----------
+        *operations : FlorinNodes
+            Operations for which direct output should be used as a dependency.
+            Maintained in the same order as they are added.
+        **keyword_operations : FlorinNodes
+            Named dependencies. The output of these operations will be stored
+            using the provided keyword.
+        """
+        graph = self.graph
+
+        # Process any data passed into the node as the input. If no data was
+        # passed in, grab any dependencies and use those as input.
+        if data is not None:
+            if not isinstance(data, tuple):
+                data = (data,)
+            result = self.operation(*data, *self.args, **self.kwargs)
+        else:
+            args = tuple([dep if not isinstance(dep, FlorinNode)
+                          else graph[dep][self][data_key]['result']
+                          for dep in self.args])
+            kwargs = {key: dep if not isinstance(dep, FlorinNode)
+                      else graph[dep][self][data_key][key]
+                      for key, dep in self.kwargs.items()}
+            result = self.operation(*args, **kwargs)
+
+        # Place the result of this operation in the output edges.
+        outedges = []
+        for _, out, key, e in graph.out_edges(self, keys=True, data=True):
+            if key is 0:
+                outedges.append((out, e))
+
+        # This implementation uses a multigraph to avoid overwriting
+        # dependencies.
+        for out, e in outedges:
+            if 'result' in e:
+                graph.add_edge(self, out, key=data_key, result=result)
+            else:
+                edge_attrs = {list(e.keys())[0]: result}
+                graph.add_edge(self, out, key=data_key, **edge_attrs)
+
+        return result
+
+    def __setattr__(self, key, val):
+        if isinstance(val, nx.DiGraph):
+            super(FlorinNode, self).__setattr__(key, weakref.ref(val))
+        super(FlorinNode, self).__setattr__(key, val)
+
+    def __hash__(self):
+        return hash(str(self.id) + self.__name__)
+
+    def add_arguments(self, *args, **kwargs):
+        """Append arguments to the list of arguments for this operation.
+
+        Parameters
+        ----------
+        *args
+            Variable list of arguments to pass into ``operation`` in order.
+
+        Notes
+        -----
+        Passing a FlorinNode as an argument will register it as a dependency
+        and pull its result to pass to ``operation``.
+
+        Passing a FlorinNode as a keyword argument will register it as a
+        dependency and pull its result to pass to ``operation`` as
+        ``key=node.result``
+        """
+        self.args = self.args + args
+        self.kwargs.update(kwargs)

--- a/florin/graph/florin_node.py
+++ b/florin/graph/florin_node.py
@@ -20,7 +20,8 @@ class MetaFlorinNode(type):
         x._counter = count(1)
         return x
 
-class FlorinNode(object, metaclass=MetaFlorinNode):
+
+class FlorinNode(obect, metaclass=MetaFlorinNode):
     """Graph node for partial function application with data dependencies.
 
     Parameters

--- a/florin/graph/florin_node.py
+++ b/florin/graph/florin_node.py
@@ -7,9 +7,12 @@ FlorinNode
 """
 
 from itertools import count
+import time
 import weakref
 
 import networkx as nx
+
+from ..log_utils import logger
 
 
 class MetaFlorinNode(type):
@@ -76,6 +79,7 @@ class FlorinNode(object, metaclass=MetaFlorinNode):
 
         # Process any data passed into the node as the input. If no data was
         # passed in, grab any dependencies and use those as input.
+        start = time.time()
         if data is not None:
             if not isinstance(data, tuple):
                 data = (data,)
@@ -88,6 +92,9 @@ class FlorinNode(object, metaclass=MetaFlorinNode):
                       else graph[dep][self][data_key][key]
                       for key, dep in self.kwargs.items()}
             result = self.operation(*args, **kwargs)
+        end = time.time()
+        logger.info('Function {0}: running time {1:0.3f}s'.format(
+                           self.__name__, end - start))
 
         # Place the result of this operation in the output edges.
         outedges = []

--- a/florin/graph/florin_node.py
+++ b/florin/graph/florin_node.py
@@ -21,7 +21,7 @@ class MetaFlorinNode(type):
         return x
 
 
-class FlorinNode(obect, metaclass=MetaFlorinNode):
+class FlorinNode(object, metaclass=MetaFlorinNode):
     """Graph node for partial function application with data dependencies.
 
     Parameters

--- a/florin/importwrapper.py
+++ b/florin/importwrapper.py
@@ -1,0 +1,51 @@
+import importlib
+import inspect
+import sys
+
+from florin.closure import florinate
+
+
+class ImportWrapper(object):
+    """Wrap imports to automatically florinate them on import.
+
+    FloRIN relies on the ``florinate()`` function to properly wrap functions
+    for partial applicaiton and deferred computation. The ``ImportWrapper``
+    tries to make imports friendly and more general by creating "backend"
+    modules that are automatically ``florinated``. The result is a slightly
+    obfuscated strategy that prepares arbitrary modules for FLoRIN on-the-fly.
+
+    Parameters
+    ----------
+    module_to_wrap : module or str
+        The module to florinate on-the-fly. If ``str``, must be the name of a
+        module that can be imported.
+
+    """
+
+    def __init__(self, module_to_wrap):
+        if inspect.ismodule(module_to_wrap):
+            self.inner_module = module_to_wrap
+        elif isinstance(module_to_wrap, str):
+            self.inner_module = importlib.import_module(module_to_wrap)
+        else:
+            raise ValueError('{} is not a Python module.'.format(
+                module_to_wrap))
+
+        self.submodules = {}
+
+    def __getattr__(self, key):
+        if key in self.__dict__['submodules']:
+            return self.__dict__['submodules'][key]
+        else:
+            try:
+                target = importlib.import_module('.'.join([self.inner_module.__name__, key]))
+            except ImportError:
+                target = getattr(self.inner_module, key)
+
+            if inspect.ismodule(target):
+                self.__dict__['submodules'][key] = ImportWrapper(target)
+                return self.__dict__['submodules'][key]
+            elif callable(target):
+                return florinate(target)
+            else:
+                return self.__dict__[key]

--- a/florin/io.py
+++ b/florin/io.py
@@ -78,7 +78,7 @@ def load(path, **kwargs):
     return img
 
 
-def load_hdf5(path, key='stack'):
+def load_hdf5(path, key='stack', keep_alive):
     """Load data from an HDF5 file.
 
     Parameters
@@ -92,9 +92,12 @@ def load_hdf5(path, key='stack'):
     -------
     data : h5py.Dataset
     """
-    f = h5py.File(path, 'r')
-    img = f[key]
-    img.file_object = f
+    f = h5py.File(path, 'r+')
+    if keep_alive:
+        img = f[key]
+        img.file_object = f
+    else:
+        img = f[key][:]
 
     return img
 

--- a/florin/io.py
+++ b/florin/io.py
@@ -78,7 +78,7 @@ def load(path, **kwargs):
     return img
 
 
-def load_hdf5(path, key='stack', keep_alive):
+def load_hdf5(path, key='stack', keep_alive=False):
     """Load data from an HDF5 file.
 
     Parameters

--- a/florin/io.py
+++ b/florin/io.py
@@ -227,7 +227,7 @@ def save(img, path, **kwargs):
     return img
 
 
-def save_hdf5(img, path, key='stack'):
+def save_hdf5(img, path, key='stack', overwrite=True):
     """Save an image to HDF5 format.
 
     Parameters
@@ -241,6 +241,9 @@ def save_hdf5(img, path, key='stack'):
         f = h5py.File(path, 'r+')
     else:
         f = h5py.File(path, 'w')
+
+    if overwrite and key in f:
+        del f[key]
     f.create_dataset(key, data=img)
 
 

--- a/florin/log_utils.py
+++ b/florin/log_utils.py
@@ -1,0 +1,42 @@
+import logging
+import sys
+
+
+class FlorinLogger(object):
+    def __init__(self, quiet=False):
+        self.logger = logging.getLogger('florin')
+
+        if not quiet:
+            self.handler = logging.StreamHandler(sys.stdout)
+            self.formatter = logging.Formatter(
+                '%(asctime)s %(name)s : %(message)s')
+            self.handler.setFormatter(self.formatter)
+        else:
+            self.handler = logging.NullHandler()
+
+        self.logger.setLevel(logging.INFO)
+        self.logger.addHandler(self.handler)
+        self.quiet = quiet
+
+    def __setattr__(self, key, val):
+        if key == 'quiet':
+            self.logger.removeHandler(self.handler)
+            self.handler = logging.StreamHandler(sys.stdout) if not val \
+                           else logging.NullHandler()
+            if not val:
+                self.handler.setFormatter(self.formatter)
+            self.logger.addHandler(self.handler)
+
+        super(FlorinLogger, self).__setattr__(key, val)
+
+    def info(self, msg):
+        self.logger.info(msg)
+
+    def quiet(self):
+        self.quiet = True
+
+    def verbose(self):
+        self.quiet = False
+
+
+logger = FlorinLogger()

--- a/florin/ndnt.py
+++ b/florin/ndnt.py
@@ -104,7 +104,7 @@ def ndnt(img, shape=None, threshold=0.25, sums=None, counts=None):
     return np.abs(1 - np.reshape(out, img.shape)).astype(np.uint8)
 
 
-def integral_image(img, inplace=False):
+def integral_image(img, dims=None, inplace=False):
     """Compute the integral image of an image or image volume.
 
     Parameters
@@ -130,9 +130,14 @@ def integral_image(img, inplace=False):
     .. [1] Tapia, E., 2011. A note on the computation of high-dimensional
        integral images. Pattern Recognition Letters, 32(2), pp.197-201.
     """
+    if dims is None:
+        dims = [1 for _ in range(img.ndim)]
+    else:
+        dims = list(dims)
     int_img = np.copy(img) if not inplace else img
     for i in range(len(img.shape) - 1, -1, -1):
-        int_img = np.cumsum(int_img, axis=i)
+        if dims[i]:
+            int_img = np.cumsum(int_img, axis=i)
     return int_img
 
 

--- a/florin/numpy.py
+++ b/florin/numpy.py
@@ -1,0 +1,8 @@
+"""Prepare scikit-image modules for use in FLoRIN pipelines"""
+
+import sys
+
+from florin.importwrapper import ImportWrapper
+
+
+sys.modules[__name__] = ImportWrapper('numpy')

--- a/florin/pipelines/__init__.py
+++ b/florin/pipelines/__init__.py
@@ -18,11 +18,12 @@ WorkQueuePipeline
 
 from .pipeline import Pipeline
 from .balsam import BalsamPipeline
-from .mpi import MPIPipeline
+from .mpi import MPIPipeline, MPITaskQueuePipeline
 from .multiprocess import MultiprocessingPipeline
 from .multithread import MultithreadingPipeline
 from .serial import SerialPipeline
 from .workqueue import WorkQueuePipeline
 
-__all__ = ['BalsamPipeline', 'MPIPipeline', 'MultiprocessingPipeline',
-           'MultithreadingPipeline', 'SerialPipeline', 'WorkQueuePipeline']
+__all__ = ['BalsamPipeline', 'MPIPipeline', 'MPITaskQueuePipeline',
+           'MultiprocessingPipeline', 'MultithreadingPipeline',
+           'SerialPipeline', 'WorkQueuePipeline']

--- a/florin/pipelines/mpi.py
+++ b/florin/pipelines/mpi.py
@@ -6,18 +6,54 @@ MPIPipeline
     MPI-based multiprocessing pipeline.
 """
 
+import inspect
+import sys
+
 import dill
-from mpi4py import MPI
-from mpi4py.futures import MPIPoolExecutor
 
 from florin.pipelines.pipeline import Pipeline
 
 
-MPI.pickle.__init__(dill.dumps, dill.loads)
-
-
 class MPIPipeline(Pipeline):
+    """MPI-based multiprocessing with MPI_Comm_spawn.
+
+    Parameters
+    ----------
+    operations : callables
+        Sequence of operations to run in the pipeline.
+    max_workers : int, optional
+        The maximum number of MPI processes to spawn. If None, scales to the
+        MPI universe size.
+
+    Notes
+    -----
+    MPI is configured by wrapping Python in an ``mpiexec`` or ``mpirun`` call
+    at runtime.
+
+    For details about using MPI_Comm_spawn through mpi4py, see the
+    `mpi4py.futures documentation`_.
+
+    .. _mpi4py.futures documentation: https://mpi4py.readthedocs.io/en/stable/mpi4py.futures.html
+
+    """
+
+    def __init__(self, *operations, max_workers=None):
+        super(MPIPipeline, self).__init__(*operations)
+        self.max_workers = max_workers
+
+    def run(self, data):
+        from mpi4py.futures import MPIPoolExecutor
+
+        with MPIPoolExecutor(max_workers=self.max_workers) as pool:
+            result = pool.map(self.operations, data)
+        return result
+
+
+class MPITaskQueuePipeline(Pipeline):
     """MPI-based multiprocessing pipeline.
+
+    Approximates a map operation using a task queue build on MPI send/recv
+    semantics. Use when MPI_Comm_spawn is unavailable.
 
     Parameters
     ----------
@@ -29,9 +65,65 @@ class MPIPipeline(Pipeline):
     MPI is configured by wrapping Python in an ``mpiexec`` or ``mpirun`` call
     at runtime.
 
+    This Pipeline instance was built to work with the Cray mpich implementation
+    of MPI, which does not necessarily provide MPI_Comm_spawn.
     """
 
     def run(self, data):
-        with MPIPoolExecutor() as executor:
-            result = executor.map(self.operations, data)
-        return result
+        from mpi4py import MPI
+        MPI.pickle.__init__(dill.dumps, dill.loads)
+
+        comm = MPI.COMM_WORLD
+        rank = comm.Get_rank()
+        size = comm.Get_size()
+        status = MPI.Status()
+
+        tags = {'READY': 0, 'DONE': 1, 'EXIT': 2, 'START': 3}
+
+        if rank == 0:
+            result = []
+
+            n_workers = size - 1
+            done = False
+
+            while n_workers > 0:
+                worker_return = comm.recv(
+                    source=MPI.ANY_SOURCE,
+                    tag=MPI.ANY_TAG,
+                    status=status)
+                source = status.Get_source()
+                tag = status.Get_tag()
+
+                if tag == tags['READY']:
+                    try:
+                        task_data = next(data) if inspect.isgenerator(data) \
+                                    else data.pop(0)
+                        task_tag = tags['START']
+                    except (IndexError, StopIteration):
+                        task_data = None
+                        task_tag = tags['EXIT']
+
+                    comm.send((self.operations, task_data),
+                              dest=source, tag=task_tag)
+                elif tag == tags['DONE']:
+                    result.append(worker_return)
+                elif tag == tags['EXIT']:
+                    n_workers -= 1
+
+            MPI.Finalize()
+            return result
+        else:
+            done = False
+            while not done:
+                comm.send(None, dest=0, tag=tags['READY'])
+                ops, task_data = comm.recv(source=0,
+                                           tag=MPI.ANY_TAG, status=status)
+                tag = status.Get_tag()
+                if tag == tags['START']:
+                    result = ops(task_data)
+                    comm.send(result, dest=0, tag=tags['DONE'])
+                elif tag == tags['EXIT']:
+                    done = True
+
+            comm.send(None, dest=0, tag=tags['EXIT'])
+            sys.exit()

--- a/florin/pipelines/mpi.py
+++ b/florin/pipelines/mpi.py
@@ -42,7 +42,9 @@ class MPIPipeline(Pipeline):
         self.max_workers = max_workers
 
     def run(self, data):
+        from mpi4py import MPI
         from mpi4py.futures import MPIPoolExecutor
+        MPI.pickle.__init__(dill.dumps, dill.loads)
 
         with MPIPoolExecutor(max_workers=self.max_workers) as pool:
             result = pool.map(self.operations, data)

--- a/florin/pipelines/pipeline.py
+++ b/florin/pipelines/pipeline.py
@@ -6,14 +6,17 @@ Pipeline
     Base pipeline.
 """
 
-import collections
+from collections import Sequence
 import functools
 import inspect
 import re
 
 import dill
+import networkx as nx
 
+from florin.closure import florinate
 from florin.compose import compose
+from florin.graph import FlorinOrderedMultiDiGraph, FlorinNode
 from florin.tiling import join
 
 
@@ -25,82 +28,61 @@ class Pipeline(object):
     operations : callables
         The operations/functions/callable classes to run in this pipeline.
 
+    Attributes
+    ----------
+    operations : florin.graph.FlorinOrderedDiGraph
+        The operations in the pipeline converted into a directed graph, with
+        operations stored as nodes and data flow/dependencies stored as edges.
     """
 
     def __init__(self, *operations):
-        self.operations = []
+        self.operations = FlorinOrderedMultiDiGraph()
 
-        for operation in operations:
-            self.add(operation)
+        tiled = False
+        subpipe = False
+
+        # Add operations to the execution graph.
+        for i, operation in enumerate(operations):
+            # Wrap any Pipeline instances in FlorinNodes before inserting into
+            # the graph
+            if isinstance(operation, Pipeline):
+                operation = FlorinNode(operation)
+
+            # If tiling and a subpipeline were supplied without an ensuing
+            # join, add a join in after the pipeline.
+            # Otherwise, if only a subpipeline was encountered with no prior
+            # tile, make sure to add the wrapped version as a dependency.
+            if tiled and subpipe and not re.search(r'join', operation.__name__):
+                join_op = join(subpipe)
+                self.operations.add(join_op)
+                operation.args = (join_op,) + operation.args
+                tiled = False
+                subpipe = False
+            elif subpipe:
+                operation.args = (subpipe,) + operation.args
+                subpipe = False
+
+            # As a convenience, if the current operation is not the first and
+            # has no dependencies, add the previous operation as a dependency.
+            depcount = sum([1 if isinstance(dep, FlorinNode) else 0
+                            for dep in operation.args])
+            if i > 0 and depcount == 0:
+                operation.args = (operations[i - 1],) + operation.args
+
+            # Insert the operation into the graph.
+            self.operations.add(operation)
+
+            # Bookeeping for finding subpipelines and tiling operations.
+            if re.search(r'Pipeline', operation.__name__):
+                subpipe = operation
+            elif re.search(r'tile', operation.__name__):
+                tiled = True
 
     def __call__(self, data):
-        for i, operation in enumerate(self.operations):
-            if not isinstance(operation, Pipeline) and re.search(r'tile_generator', operation.__name__):
-                if len(self.operations) > i + 1 and not isinstance(self.operations[i + 1], Pipeline):
-                    start = i + 1
-                    end = start
-                    for j, subop in enumerate(self.operations[start:]):
-                        if re.search(r'join_tiles|save', subop.__name__):
-                            break
-                        end += 1
-
-                    if end == len(self.operations):
-                        self.operations.append(join())
-
-                    subops = self.operations[start:end]
-                    self.operations[start] = self.__class__(*subops)
-                    for j in range(start + 1, end):
-                        self.operations.pop(j)
-            if isinstance(operation, Pipeline):
-                try:
-                    if not re.search(r'reconstruct', self.operations[i + 1].__name__):
-                        self.operations.insert(i + 1, join())
-                except IndexError:
-                    self.operations.append(join())
-
-        self.operations = compose(*self.operations)
-        if isinstance(data, (str, tuple)) or not inspect.isgenerator(data) and not isinstance(data, collections.Sequence):
+        # Wrap data to be an iterable if it is not one already.
+        if not isinstance(data, Sequence) and not inspect.isgenerator(data) or isinstance(data, str):
             data = [data]
         return self.run(data)
-
-    def __contains__(self, func):
-        return func in self.operations \
-            or any([o.__name__ == func.__name__ for o in self.operations])
-
-    def __getitem__(self, start, stop=None, step=1):
-        return self.operations[start] if stop is None \
-            else self.operations[slice(start, stop, step)]
-
-    def __setitem__(self, idx, func):
-        self.operations[idx] = func
-
-    def __len__(self):
-        return len(self.operations)
-
-    def add(self, func):
-        """Append a callable to this pipeline.
-
-        Parameters
-        ----------
-        func : callable
-            New function to add.
-        """
-        self.operations.append(func)
-
-    def dump(self, path):
-        """Save this pipeline to file.
-
-        Parameters
-        ----------
-        path : str
-            Path to the file to write this pipeline to.
-        """
-        with open(path, 'w') as f:
-            dill.dump(self, path)
-
-    def dumps(self):
-        """Serialize this pipeline as a string."""
-        return dill.dumps(self)
 
     def run(self, data):
         """Run data through the pipeline.
@@ -108,11 +90,17 @@ class Pipeline(object):
         Parameters
         ----------
         data
-            Input to the first function in the pipeline.
+            The input to the first function in the pipeline.
 
         Returns
         -------
         result
-            The result of applying the pipeline to ``data``.
+            The final output of applying the pipeline to ``data``.
+
+        Notes
+        -----
+        To implement new kinds of execution models, this function should be
+        overridden. See other subclasses in the ``florin.pipelines`` module for
+        examples of how to override ``run()``.
         """
         raise NotImplementedError

--- a/florin/pipelines/pipeline.py
+++ b/florin/pipelines/pipeline.py
@@ -99,6 +99,16 @@ class Pipeline(object):
             data = [data]
         return self.run(data)
 
+    def dump(self, fp):
+        """Serialize the pipeline and operations.
+
+        Parameters
+        ----------
+        fp : File
+            File to write the serialization to.
+        """
+        dill.dump(self, fp)
+
     def run(self, data):
         """Run data through the pipeline.
 
@@ -119,6 +129,18 @@ class Pipeline(object):
         examples of how to override ``run()``.
         """
         raise NotImplementedError
+
+    @staticmethod
+    def load(cls, fp):
+        """Deserialize a pipeline.
+
+        Parameters
+        ----------
+        fp : File
+            File pointer to the serialized pipeline.
+        """
+        pipe = dill.load(fp)
+        return fp
 
 
 class PipelineInput(object):

--- a/florin/pipelines/pipeline.py
+++ b/florin/pipelines/pipeline.py
@@ -74,9 +74,11 @@ class Pipeline(object):
                 operation.args = (in_node,) + operation.args
 
             # Automatically impute references to this pipeline's input
-            for j, arg in enumerate(operation.args):
+            opargs = list(operation.args)
+            for j, arg in enumerate(opargs):
                 if arg is PipelineInput or isinstance(arg, PipelineInput):
-                    operation.args[j] = in_node
+                    opargs[j] = in_node
+            operation.args = tuple(opargs)
 
             for key, arg in operation.kwargs.items():
                 if arg is PipelineInput or isinstance(arg, PipelineInput):

--- a/florin/pipelines/serial.py
+++ b/florin/pipelines/serial.py
@@ -23,4 +23,4 @@ class SerialPipeline(Pipeline):
 
     def run(self, data):
         result = map(self.operations, data)
-        return result
+        return list(result)

--- a/florin/pipelines/serial.py
+++ b/florin/pipelines/serial.py
@@ -23,5 +23,8 @@ class SerialPipeline(Pipeline):
 
     def run(self, data):
         result = map(self.operations, data)
-        return result if inspect.isgenerator(data) or len(data) > 1 \
-               else next(result)
+        try:
+            return result if inspect.isgenerator(data) or len(data) > 1 \
+                   else next(result)
+        except StopIteration:
+            return None

--- a/florin/pipelines/serial.py
+++ b/florin/pipelines/serial.py
@@ -23,8 +23,4 @@ class SerialPipeline(Pipeline):
 
     def run(self, data):
         result = map(self.operations, data)
-        try:
-            return result if inspect.isgenerator(data) or len(data) > 1 \
-                   else next(result)
-        except StopIteration:
-            return None
+        return result

--- a/florin/run.py
+++ b/florin/run.py
@@ -6,12 +6,12 @@ deserialize_and_run
     Load a serialized pipeline and run it on provided data.
 """
 
-import dill
+from florin.pipelines.pipeline import Pipeline
 
 
 def deserialize_and_run(path, data):
     with open(path, 'r') as f:
-        pipeline = dill.load(f)
+        pipeline = Pipeline.load(f)
     return pipeline(data)
 
 

--- a/florin/scipy.py
+++ b/florin/scipy.py
@@ -1,0 +1,8 @@
+"""Prepare scikit-image modules for use in FLoRIN pipelines"""
+
+import sys
+
+from florin.importwrapper import ImportWrapper
+
+
+sys.modules[__name__] = ImportWrapper('scipy')

--- a/florin/skimage.py
+++ b/florin/skimage.py
@@ -1,0 +1,8 @@
+"""Prepare scikit-image modules for use in FLoRIN pipelines"""
+
+import sys
+
+from florin.importwrapper import ImportWrapper
+
+
+sys.modules[__name__] = ImportWrapper('skimage')

--- a/florin/tiling.py
+++ b/florin/tiling.py
@@ -12,7 +12,7 @@ import h5py
 import numpy as np
 
 from florin.closure import florinate
-from florin.context import FlorinContext
+from florin.context import FlorinMetadata
 
 
 class DimensionMismatchError(ValueError):
@@ -47,7 +47,7 @@ def tile_generator(img, shape=None, stride=None, offset=None, tile_store=None):
     tile : florin.FlorinVolume
         A subdivision of ``img``. Subdivisions are yielded in sequence from the
         start of ``img``.
-    metadata : dictionary
+    metadata : florin.context.Metadata
         Key/value store of metadata, e.g. for joining tiles.
 
     Notes
@@ -104,12 +104,10 @@ def tile_generator(img, shape=None, stride=None, offset=None, tile_store=None):
         end = start + shape
         over = np.where(end > np.asarray(img.shape))
         end[over] = np.asarray(img.shape)[over]
-        # print(end)
         slices = [slice(start[j], end[j]) for j in range(len(shape))]
         block = img[tuple(slices)]
-        # if block.size > 0:
         yield block, \
-              FlorinContext(original_shape=img.shape, origin=tuple(start))
+              FlorinMetadata(original_shape=img.shape, origin=tuple(start))
 
 
 def join_tiles(tiles):

--- a/florin/tiling.py
+++ b/florin/tiling.py
@@ -11,6 +11,8 @@ join_tiles
 import h5py
 import numpy as np
 
+from cloudvolume import CloudVolume
+
 from florin.closure import florinate
 from florin.context import FlorinMetadata
 
@@ -108,7 +110,15 @@ def tile_generator(img, shape=None, stride=None, offset=None, tile_store=None):
         over = np.where(end > np.asarray(img.shape))
         end[over] = np.asarray(img.shape)[over]
         slices = [slice(start[j], end[j]) for j in range(len(shape))]
+
+        if isinstance(block, CloudVolume):
+            slices = slices[::-1]
+
         block = img[tuple(slices)]
+
+        if isinstance(block, CloudVolume):
+            block = np.transpose(block, axes=(2, 1, 0))
+
         yield block, \
               FlorinMetadata(original_shape=img.shape, origin=tuple(start))
 

--- a/florin/tiling.py
+++ b/florin/tiling.py
@@ -111,7 +111,7 @@ def tile_generator(img, shape=None, stride=None, offset=None, tile_store=None):
         end[over] = np.asarray(img.shape)[over]
         slices = [slice(start[j], end[j]) for j in range(len(shape))]
 
-        if isinstance(block, CloudVolume):
+        if isinstance(img, CloudVolume):
             slices = slices[::-1]
 
         block = img[tuple(slices)]

--- a/florin/tiling.py
+++ b/florin/tiling.py
@@ -90,7 +90,10 @@ def tile_generator(img, shape=None, stride=None, offset=None, tile_store=None):
 
     # Get the number of volumes
     img_shape = np.asarray(img.shape)
-    blocked_shape = ((img_shape - offset) / stride).astype(np.int32)
+    blocked_shape = ((img_shape - offset) / stride)
+    for i in range(1, blocked_shape.ndim):
+        blocked_shape[i] = np.ceil(blocked_shape[i])
+    blocked_shape = blocked_shape.astype(np.int32)
     n_blocks = int(np.prod(blocked_shape))
 
     start_block = np.ravel_multi_index(
@@ -137,7 +140,7 @@ def join_tiles(tiles):
 
         out[tuple(slices)] += tile
 
-    return out.astype(tile.dtype)
+    return out
 
 
 tile = florinate(tile_generator)

--- a/florin/util.py
+++ b/florin/util.py
@@ -1,0 +1,66 @@
+"""Helper functions for modifying the grayscale histogram of an image.
+
+Functions
+---------
+img_as_float32
+    Convert an image to single-precision (32-bit) floating point format.
+img_as_float64
+    Convert an image to double-precision (64-bit) floating point format.
+img_as_float
+    Convert an image to floating point format.
+img_as_int
+     	Convert an image to 16-bit signed integer format.
+img_as_uint
+    Convert an image to 16-bit unsigned integer format.
+img_as_ubyte
+    Convert an image to 8-bit unsigned integer format.
+img_as_bool
+    Convert an image to boolean format.
+view_as_blocks
+    Block view of the input n-dimensional array (using re-striding).
+pad
+    Pads an array.
+crop
+    Crop array ar by crop_width along each dimension.
+random_noise
+    Function to add random noise of various types to a floating-point image.
+regular_grid
+    Find n_points regularly spaced along ar_shape.
+regular_seeds
+    Return an image with ~`n_points` regularly-spaced nonzero pixels.
+invert
+    Invert an image.
+
+Notes
+-----
+The functions defined here are wrappers for functions in the `skimage.util`
+module. Full documentation may be found in the `scikit-image documentation`_.
+
+.. _scikit-image documentation: https://scikit-image.org/docs/stable/api/skimage.util.html
+
+"""
+
+import skimage.util
+
+from florin.closure import florinate
+
+
+img_as_float32 = florinate(skimage.util.img_as_float32)
+img_as_float64 = florinate(skimage.util.img_as_float64)
+img_as_float = florinate(skimage.util.img_as_float)
+img_as_int = florinate(skimage.util.img_as_int)
+img_as_uint = florinate(skimage.util.img_as_uint)
+img_as_ubyte = florinate(skimage.util.img_as_ubyte)
+img_as_bool = florinate(skimage.util.img_as_bool)
+view_as_blocks = florinate(skimage.util.view_as_blocks)
+pad = florinate(skimage.util.pad)
+crop = florinate(skimage.util.crop)
+random_noise = florinate(skimage.util.random_noise)
+regular_grid = florinate(skimage.util.regular_grid)
+regular_seeds = florinate(skimage.util.regular_seeds)
+invert = florinate(skimage.util.invert)
+
+__all__ = ['img_as_float32', 'img_as_float64', 'img_as_float', 'img_as_int',
+           'img_as_uint', 'img_as_ubyte', 'img_as_bool', 'view_as_blocks',
+           'pad', 'crop', 'random_noise', 'regular_grid', 'regular_seeds',
+           'invert']

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     install_requires=[
         'h5py',
         'mpi4py>=3.0.0',
+        'networkx',
         'numpy',
         'pathos',
         'scikit-image',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     url='https://github.com/jeffkinnison/florin',
     author='Jeff Kinnison, Elia Shahbazi',
     author_email='jkinniso@nd.edu, ashahbaz@nd.edu',
-    packages=['florin', 'florin.pipelines'],
+    packages=['florin', 'florin.graph', 'florin.pipelines'],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Science/Research',


### PR DESCRIPTION
# Changelog

## Enhancements

- FLoRIN now uses `networkx` internally to create directed graphs of operations and data flow.
- Dependencies may be injected by referencing other operations when setting up the pipeline.
- A second MPI processing pipeline has been introduces. This pipeline only uses standard send/recv semantics and is intended for systems that do not support `MPI_Comm_spawn()`.

## Bug Fixes

- FLoRIN no longer crashes after completing the final operation in the pipeline. Functionally speaking, this changes nothing, but now you won't see Python tracebacks when things succeed.
- On some systems, NDNT would encounter a `numpy` [bug when processing floating-point arrays](https://software.intel.com/en-us/forums/intel-distribution-for-python/topic/724128 "cumsum error on large float arrays"). This was cleverly fixed by switching to integers.

## Issues Addressed

- #6 Digraph-based Pipelines
- #7 Crash when ending with a Pipeline object
- #8  MPI - Static Scheduling and Task Execution